### PR TITLE
Make Python 3.6 compatible

### DIFF
--- a/pxng/keys.py
+++ b/pxng/keys.py
@@ -150,7 +150,7 @@ class KeyState:
     held: bool = False
 
     def __str__(self):
-        return f'{self.pressed = } {self.released = } {self.held = }'
+        return f'self.pressed={self.pressed} self.released={self.released} self.held={self.held}'
 
 
 class KeyPoller:

--- a/pxng/mouse.py
+++ b/pxng/mouse.py
@@ -34,7 +34,7 @@ class MouseButtonState:
     """
 
     def __str__(self):
-        return f'{self.pressed = } {self.released = } {self.held = }'
+        return f'self.pressed={self.pressed} self.released={self.released} self.held={self.held}'
 
 
 class Mouse:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyopengl~=3.1.0
 freetype-py~=2.2.0
 numpy~=1.19.2
 imageio~=2.9.0
+dataclasses ; python_version < '3.7'

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,13 @@ setuptools.setup(
         'pyopengl>=3.1.0',
         'freetype-py>=2.2.0',
         'numpy>=1.19.0',
-        'imageio>=2.9.0'
+        'imageio>=2.9.0',
     ],
+    extras_require={
+        ':python_version < "3.7"': [
+            'dataclasses',
+        ],
+    },
     package_data={'pxng': ['resources/fonts/C64_Pro_Mono-STYLE.ttf']},
     python_requires='>=3.6',
 )


### PR DESCRIPTION
This package is nearly Python 3.6 compatible:

* Python 3.6 supports f-strings, but not _debug_ strings.  They are not very necessary.
* Python 3.6 does not have dataclasses, but [dataclasses has been backported](https://pypi.org/project/dataclasses/)

1. Rewrite debug strings to normal f-strings.
2. Add dataclass as requirement for users on Python 3.6.